### PR TITLE
We shouldn't restrict the config limit people are able to set

### DIFF
--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -62,6 +62,9 @@ module.exports = {
 		}
 		else if (subCommand === 'playlistmax') {
 			const limit = interaction.options.getInteger('limit');
+			if (limit < 1) {
+				return interaction.editReply('You cannot set a negative limit.');
+			}
 
 			await interaction.client.db.setAsync(`librenote:settings:${interaction.guild.id}:playlistmax`, limit);
 			return interaction.editReply(`Successsfully set the playlist item limit to **${limit} ${limit == 1 ? 'item' : 'items'}**`);


### PR DESCRIPTION
In the future, we can make it so we read more than 50 songs with the YouTube API. No need to limit the configurations, though the default will stay as 50. 